### PR TITLE
fix: 옵션 삭제시 클릭된 옵션 설정 초기화

### DIFF
--- a/FE/src/components/fundingDetail/Info/InfoOption.tsx
+++ b/FE/src/components/fundingDetail/Info/InfoOption.tsx
@@ -51,6 +51,7 @@ export default function InfoOption({ options }: Readonly<Props>) {
             clicked={clicked}
             setClicked={(v: number | undefined) => setClicked(v)}
             deleteOption={() => {
+              setClicked(undefined);
               setSelected(
                 selected.filter((item) => item.optionId !== option.optionId)
               );


### PR DESCRIPTION
 옵션 삭제시 클릭된 옵션 설정 초기화

#46

## PR 유형

- [ ] 새로운 기능 추가
- [x] 버그 수정
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## PR 내용

- 옵션 클릭시 해당 옵션이 선택되어있다는 것을 상태로 저장하였고, 해당 옵션만 크게 보이도록 만들었었다. 
- 이때 옵션을 클릭해고 삭제하면 해당 옵션을 제외하고 타 옵션이 보이지 않게 되는 버그

## 기타

- 기타 내용 (없을 시 삭제)

close #46 