### PR TITLE
fix: 리프레시시 총 금액 사라지는 버그 수정

### DIFF
--- a/FE/src/components/common/icons/Coin.tsx
+++ b/FE/src/components/common/icons/Coin.tsx
@@ -11,7 +11,7 @@ export default function Coin({ size, style }: Readonly<Props>) {
       ? "w-5 h-5 text-[1.125rem] -translate-y-[0.1rem]"
       : size == "md"
       ? "w-6 h-6 text-[1.4rem]"
-      : "w-7 h-7";
+      : "w-8 h-8 + inline-block";
   return (
     <Image
       alt="Coin"

--- a/FE/src/components/pledge/Payment.tsx
+++ b/FE/src/components/pledge/Payment.tsx
@@ -1,13 +1,13 @@
-import { TotalCostState } from "@/store/FundingState";
-import { useRecoilValue } from "recoil";
 import useCharge from "@/hooks/useCharge";
 import Agreement from "./Agreement";
 import PaymentBtn from "./PaymentBtn";
+import { getLocalTotalCost } from "@/utils/payment";
+import { Coin } from "../common/icon";
 
 export default function Payment({
   type,
 }: Readonly<{ type: "DONATE" | "GIFT" }>) {
-  const totalCost = useRecoilValue(TotalCostState);
+  const totalCost = getLocalTotalCost();
   const { data, error, isLoading } = useCharge();
   return (
     <div className="relative py-11 px-10 z-50">
@@ -18,9 +18,12 @@ export default function Payment({
         </p>
         <p className="text-end flex justify-between items-center text-[1.375rem] text-[#696969]">
           <span>최종 결제 금액 : </span>
-          <span className="font-black text-[2.5rem] text-color121">
-            {totalCost}
-          </span>
+          <div className="flex items-center gap-3">
+            <span className="font-black text-[2.5rem] text-color121">
+              {totalCost}
+            </span>
+            <Coin size="lg" />
+          </div>
         </p>
       </div>
       <hr className="border-color999 border-2 mt-5" />

--- a/FE/src/utils/localData.ts
+++ b/FE/src/utils/localData.ts
@@ -47,3 +47,10 @@ export const updateLocalOption = (option: SelectedOption[]) => {
   data.options = option;
   setLocalData(data.memberId, data.options);
 };
+
+/**옵견값만 가져온다. */
+export const getOptionData = () => {
+  initLocalData();
+  const data = getLocalData();
+  return data.options;
+};

--- a/FE/src/utils/payment.ts
+++ b/FE/src/utils/payment.ts
@@ -1,9 +1,16 @@
 import { SelectedOption } from "@/Model/Funding";
+import { getOptionData } from "./localData";
 
 export const calTotalCost = (options: SelectedOption[]) => {
   let total = 0;
   options.forEach((option) => {
     total += option.amount * option.price;
   });
+  return total;
+};
+
+export const getLocalTotalCost = () => {
+  const options = getOptionData();
+  const total = calTotalCost(options);
   return total;
 };


### PR DESCRIPTION
로컬상에서 가져오도록 변경

#60

## PR 유형

- [ ] 새로운 기능 추가
- [x] 버그 수정
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## PR 내용

- 리프레시 하였을 때 상태값이 날아가 최종 금액이 날아가는 문제 해결
- 전역 상태로 사용자가 선택한 옵션을 저장해두었는데, 이 때문에 리프레시 하였을 때 상태값이 다시 초기화 되어 최종 결제 금액이 사라지는 버그
- 옵션의 내용은 로컬스토리지에도 저장되어 있으므로 이를 활용하여 다시 계산하는 방식으로 해결

## 기타

- 기타 내용 (없을 시 삭제)

close #60 